### PR TITLE
Port to Isabelle 2019

### DIFF
--- a/Wasm_Assertions_Shallow.thy
+++ b/Wasm_Assertions_Shallow.thy
@@ -475,6 +475,22 @@ lemma ass_wf_conseq1:
   unfolding ass_wf_def
   by (auto simp add: reifies_lab_def reifies_ret_def)
 
+lemma rel_option_to_eq_map_option:
+  assumes
+    "rel_option f x y" and
+    "\<And>a b. f a b \<Longrightarrow> g a = g b"
+  shows "map_option g x = map_option g y"
+  using assms
+  by (induction x y rule: option.rel_induct; simp)
+
+lemma list_all2_to_eq_map:
+  assumes
+    "list_all2 f xs ys" and
+    "\<And>a b. f a b \<Longrightarrow> g a = g b"
+  shows "map g xs = map g ys"
+  using assms
+  by (induction xs ys rule: list.rel_induct; simp)
+
 lemma ass_wf_conseq2:
   assumes "ass_wf lvar_st ret (fs,ls,rs) labs locs s hf st h vcs P"
           "(list_all2 (\<lambda>L L'. (ass_stack_len L = ass_stack_len L') \<and> ass_conseq L L' vcs h st) ls ls')"
@@ -484,8 +500,8 @@ proof -
   show ?thesis
     using assms
     unfolding ass_wf_def ass_conseq_def
-    by (fastforce simp add: list_all2_conv_all_nth nth_equalityI reifies_lab_def option.rel_sel
-                            reifies_ret_def)
+    unfolding reifies_lab_def reifies_ret_def
+    by (auto intro: list_all2_to_eq_map rel_option_to_eq_map_option)
 qed
 
 lemma valid_triple_assms_n_label_false:

--- a/Wasm_Big_Step.thy
+++ b/Wasm_Big_Step.thy
@@ -947,7 +947,7 @@ lemma reduce_to_n_store:
   assumes "((s,vs,($$*ves)@[$C (ConstInt32 c), $C v, $Store t None a off]) \<Down>k{(ls,r,i)} (s',vs',res))"
   shows "vs = vs' \<and> types_agree t v \<and> (\<exists>j m. smem_ind s i = Some j \<and> s.mem s ! j = m \<and>
            ((s = s' \<and> store (s.mem s ! j) (Wasm_Base_Defs.nat_of_int c) off (bits v) (t_length t) = None \<and> res = RTrap) \<or>
-            (\<exists>mem'. store (s.mem s ! j) (Wasm_Base_Defs.nat_of_int c) off (bits v) (t_length t) = Some mem' \<and> s' = s\<lparr>s.mem := s.mem s[j := mem']\<rparr> \<and> res = RValue ves)))"
+            (\<exists>mem'. store (s.mem s ! j) (Wasm_Base_Defs.nat_of_int c) off (bits v) (t_length t) = Some mem' \<and> s' = s\<lparr>s.mem := (s.mem s)[j := mem']\<rparr> \<and> res = RValue ves)))"
   using assms
 proof (induction "(s,vs,($$*ves)@[$C (ConstInt32 c), $C v, $Store t None a off])" k "(ls,r,i)" "(s',vs',res)" arbitrary: s vs vs' s' res ves k rule: reduce_to_n.induct)
   case (const_value s vs es k s' vs' res ves ves')
@@ -999,7 +999,7 @@ lemma reduce_to_n_store_packed:
   assumes "((s,vs,($$*ves)@[$C (ConstInt32 c), $C v, $Store t (Some tp) a off]) \<Down>k{(ls,r,i)} (s',vs',res))"
   shows "vs = vs' \<and> types_agree t v \<and> (\<exists>j m. smem_ind s i = Some j \<and> s.mem s ! j = m \<and>
            ((s = s' \<and> store (s.mem s ! j) (Wasm_Base_Defs.nat_of_int c) off (bits v) (tp_length tp) = None \<and> res = RTrap) \<or>
-            (\<exists>mem'. store (s.mem s ! j) (Wasm_Base_Defs.nat_of_int c) off (bits v) (tp_length tp) = Some mem' \<and> s' = s\<lparr>s.mem := s.mem s[j := mem']\<rparr> \<and> res = RValue ves)))"
+            (\<exists>mem'. store (s.mem s ! j) (Wasm_Base_Defs.nat_of_int c) off (bits v) (tp_length tp) = Some mem' \<and> s' = s\<lparr>s.mem := (s.mem s)[j := mem']\<rparr> \<and> res = RValue ves)))"
   using assms
 proof (induction "(s,vs,($$*ves)@[$C (ConstInt32 c), $C v, $Store t (Some tp) a off])" k "(ls,r,i)" "(s',vs',res)" arbitrary: s vs vs' s' res ves k rule: reduce_to_n.induct)
   case (const_value s vs es k s' vs' res ves ves')
@@ -1484,7 +1484,7 @@ lemma no_reduce_to_n_grow_memory:
 
 lemma reduce_to_n_grow_memory:
   assumes "((s,vs,($$*ves)@[$C ConstInt32 c, $Grow_memory]) \<Down>k{(ls,r,i)} (s',vs',res))"
-  shows "\<exists>n j m. (vs = vs' \<and> smem_ind s i = Some j \<and> ((mem s)!j) = m \<and> mem_size m = n) \<and> ((s = s' \<and> res = RValue (ves@[ConstInt32 int32_minus_one])) \<or> (s' = s \<lparr>s.mem := s.mem s [j := mem_grow (s.mem s ! j) (Wasm_Base_Defs.nat_of_int c)]\<rparr> \<and> res = RValue (ves@[ConstInt32 (int_of_nat n)])))"
+  shows "\<exists>n j m. (vs = vs' \<and> smem_ind s i = Some j \<and> ((mem s)!j) = m \<and> mem_size m = n) \<and> ((s = s' \<and> res = RValue (ves@[ConstInt32 int32_minus_one])) \<or> (s' = s \<lparr>s.mem := (s.mem s)[j := mem_grow (s.mem s ! j) (Wasm_Base_Defs.nat_of_int c)]\<rparr> \<and> res = RValue (ves@[ConstInt32 (int_of_nat n)])))"
   using assms
 proof (induction "(s,vs,($$*ves)@[$C ConstInt32 c, $Grow_memory])" k "(ls,r,i)" "(s',vs',res)" arbitrary: s vs vs' res ves k rule: reduce_to_n.induct)
   case (const_value s vs es k vs' res ves ves')

--- a/Wasm_Inference_Rules.thy
+++ b/Wasm_Inference_Rules.thy
@@ -491,7 +491,7 @@ lemma set_local_differ:
           "(inst.globs i ! x1) < length (s.globs s)"
   shows "s.globs s ! (inst.globs i ! x1) =
           s.globs
-            (s\<lparr>s.globs := s.globs s
+            (s\<lparr>s.globs := (s.globs s)
                     [(inst.globs i ! j) :=
      (s.globs s ! (inst.globs i ! j))\<lparr>g_val := v\<rparr>]\<rparr>) !
            (inst.globs i ! x1)"
@@ -3704,7 +3704,7 @@ next
                                        (Wasm_Base_Defs.nat_of_int c) off
                                        (bits v) (t_length t) =
                                       Some mem' \<and>
-                                      s' = s\<lparr>s.mem := s.mem s[j := mem']\<rparr> \<and>
+                                      s' = s\<lparr>s.mem := (s.mem s)[j := mem']\<rparr> \<and>
                                       res = RValue vcsf))"
       using reduce_to_n_store[OF 1]
       by blast
@@ -3731,7 +3731,7 @@ next
       unfolding reifies_s_def reifies_heap_def
       by (metis 2(3,4) option.sel smem_ind_def)
     have res_is:"store (s.mem s ! j) (Wasm_Base_Defs.nat_of_int c) off (bits v) (t_length t) = Some m'"
-         "s' = s\<lparr>s.mem := s.mem s[j := m']\<rparr>"
+         "s' = s\<lparr>s.mem := (s.mem s)[j := m']\<rparr>"
          "res = RValue vcsf"
       using 2(4,5) 7 m'_def(1)
       unfolding store_def
@@ -3796,7 +3796,7 @@ next
                                        (Wasm_Base_Defs.nat_of_int c) off
                                        (bits v) (tp_length tp) =
                                       Some mem' \<and>
-                                      s' = s\<lparr>s.mem := s.mem s[j := mem']\<rparr> \<and>
+                                      s' = s\<lparr>s.mem := (s.mem s)[j := mem']\<rparr> \<and>
                                       res = RValue vcsf))"
       using reduce_to_n_store_packed[OF 1]
       by blast
@@ -3823,7 +3823,7 @@ next
       unfolding reifies_s_def reifies_heap_def
       by (metis 2(3,4) option.sel smem_ind_def)
     have res_is:"store (s.mem s ! j) (Wasm_Base_Defs.nat_of_int c) off (bits v) (tp_length tp) = Some m'"
-         "s' = s\<lparr>s.mem := s.mem s[j := m']\<rparr>"
+         "s' = s\<lparr>s.mem := (s.mem s)[j := m']\<rparr>"
          "res = RValue vcsf"
       using 2(4,5) 7 m'_def(1)
       unfolding store_def
@@ -4203,7 +4203,7 @@ next
            (s = s' \<and> res = RValue (vcsf @ [ConstInt32 int32_minus_one]))"
     | (2) "\<exists>n j m.
            (locs = locs' \<and> smem_ind s i = Some j \<and> s.mem s ! j = m \<and> mem_size m = n) \<and>
-           (s' = s\<lparr>s.mem := s.mem s[j := mem_grow (s.mem s ! j)(Wasm_Base_Defs.nat_of_int k_g)]\<rparr> \<and>
+           (s' = s\<lparr>s.mem := (s.mem s)[j := mem_grow (s.mem s ! j)(Wasm_Base_Defs.nat_of_int k_g)]\<rparr> \<and>
             res = RValue (vcsf @ [ConstInt32 (Wasm_Base_Defs.int_of_nat n)]))"
       using reduce_to_n_grow_memory[OF 0]
       by fastforce
@@ -4241,7 +4241,7 @@ next
                                             "smem_ind s i = Some j_m"
                                             "s.mem s ! j_m = m_m"
                                             "mem_size m_m = n_m"
-                                            "s' = s\<lparr>s.mem := s.mem s[j_m := mem_grow (s.mem s ! j_m)(Wasm_Base_Defs.nat_of_int k_g)]\<rparr>"
+                                            "s' = s\<lparr>s.mem := (s.mem s)[j_m := mem_grow (s.mem s ! j_m)(Wasm_Base_Defs.nat_of_int k_g)]\<rparr>"
                                             "res = RValue (vcsf @ [ConstInt32 (int_of_nat n_m)])"
         by fastforce
       have "\<exists>h''.

--- a/WebAssembly/Wasm_Properties_Aux.thy
+++ b/WebAssembly/Wasm_Properties_Aux.thy
@@ -1399,9 +1399,9 @@ lemma store_extension_refl:
 lemma store_extension_mem_leq:
   assumes "s.mem s ! j = m"
           "mem_size m \<le> mem_size m'"
-  shows "store_extension s (s\<lparr>s.mem := s.mem s[j := m']\<rparr>)"
+  shows "store_extension s (s\<lparr>s.mem := (s.mem s)[j := m']\<rparr>)"
 proof -
-  obtain s' where s'_def:"s' = (s\<lparr>s.mem := s.mem s[j := m']\<rparr>)"
+  obtain s' where s'_def:"s' = (s\<lparr>s.mem := (s.mem s)[j := m']\<rparr>)"
     by blast
   hence "funcs s = funcs s'"
         "tab s = tab s'"
@@ -1438,7 +1438,7 @@ lemma update_glob_store_extension:
 proof -
   obtain k where k_def:"k = (sglob_ind s i j)"
     by blast
-  hence s'_def:"s' = s\<lparr>s.globs := s.globs s[k := (s.globs s ! k)\<lparr>g_val := v\<rparr>]\<rparr>"
+  hence s'_def:"s' = s\<lparr>s.globs := (s.globs s)[k := (s.globs s ! k)\<lparr>g_val := v\<rparr>]\<rparr>"
     using assms(1)
     unfolding supdate_glob_def sglob_ind_def supdate_glob_s_def
     by metis


### PR DESCRIPTION
Add explicit parentheses because of new precedence of list_update operator.
From Isabelle 2019 NEWS/HOL:

> * Theory List: the precedence of the list_update operator has changed:
> "f a [n := x]" now needs to be written "(f a)[n := x]".

One insance of fastforce failed with the new release. Refactor the proof to use
auto and two extra lemmata. Proof is more explicit and should be more future proof.